### PR TITLE
Installation requirements modified for correct pip install

### DIFF
--- a/requirements/dynetworkx.txt
+++ b/requirements/dynetworkx.txt
@@ -2,4 +2,4 @@ networkx>=2.0
 sortedcontainers
 numpy
 timeit
-sklearn
+scikit-learn


### PR DESCRIPTION
Following the issue with pip install as mentioned #1 , I've added the minimal change required in the requirements/dynetworkx.txt
The changes are tested on Ubuntu 18.04 and the install works.